### PR TITLE
add failing test for index path /

### DIFF
--- a/test.js
+++ b/test.js
@@ -24,6 +24,20 @@ test('register a single callback on GET', function (t) {
   http.get('http://localhost:' + getPort(server) + '/foo')
 })
 
+test('register an index path', function (t) {
+  t.plan(1)
+  const router = serverRouter()
+
+  router.on('/', function (req, res) {
+    t.pass('called')
+    res.end()
+    server.close()
+  })
+
+  const server = http.createServer(router).listen()
+  http.get('http://localhost:' + getPort(server) + '/')
+})
+
 test('register a default path', function (t) {
   t.plan(1)
   const router = serverRouter('/404')


### PR DESCRIPTION
hey @yoshuawuyts, i was following along with the [`bankai` docs](https://github.com/yoshuawuyts/bankai), but couldn't fetch the index html page. it seems something is broken (?), so here's a failing test. :)

it seems to do with the index path `/` being registered on wayfarer as `//GET`. when creating the trie node, the first `/` is stripped, so it becomes `/GET`, which is split into `['', 'GET']`. however, this is different than the incoming request urls which are `/GET` and split to `['GET']`. i'm sure you'll have a better idea than me of how best to solve this.
