### PR TITLE
router: add wrap method

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,42 @@ separate files, but at the top level it's clear which routes are handled by
 which handlers. Server-router supports arbitrary nesting, so go ahead and
 structure your files exactly as you like.
 
+## Custom frontends
+When building real-world applications, it's common to perform actions such as
+validation of data, validation of headers and more. To do this it can be useful
+to wrap routes in a custom function that performs these actions. Here's an
+example using `api-gateway`:
+```js
+const serverRouter = require('server-router')
+const apiGateway = require('api-gateway')
+const http = require('http')
+
+const gateway = apiGateway()
+const router = createRouter('/404', { wrap: gateway })
+router.on('/', {
+  get: {
+    description: 'Returns the API index page',
+    accepts: [ 'application/json' ],
+    responds: [ 'application/json' ],
+    handler: function (req, res, params) {}
+  }
+})
+
+router.on('/foo', {
+  description: 'Returns the foo endpoint',
+  handler: function (req, res, params) {}
+})
+
+http.createServer(router).listen()
+```
+
 ## API
-### router = serverRouter(default)
+### router = serverRouter(default, options)
 Create a new router with a default path. If no default path is set, the router
-will crash if an unknown path is encountered.
+will crash if an unknown path is encountered. Options is an object with the
+following options:
+- __wrap:__ provide a custom frontend wrapper to perform common actions. See
+  [custom-frontends](#custom-frontends) for a usage example.
 
 ### router.on(route, callback|obj)
 Attach a callback to a route. Callback can be either a function, which is
@@ -103,6 +135,14 @@ functions can return values, which is useful to create pipelines.
 ```sh
 $ npm install server-router
 ```
+
+## See Also
+- [wayfarer](https://github.com/yoshuawuyts/wayfarer) - vanilla radix-trie
+  router
+- [sheet-router](https://github.com/yoshuawuyts/sheet-router) - client-side
+  radix-trie router
+- [server-gateway](https://github.com/yoshuawuyts/server-gateway) - server
+  middleware collection
 
 ## License
 [MIT](https://tldrlegal.com/license/mit-license)

--- a/index.js
+++ b/index.js
@@ -9,10 +9,17 @@ module.exports = serverRouter
 
 // Server router
 // str -> fn -> any
-function serverRouter (dft) {
+function serverRouter (dft, opts) {
+  if (typeof dft === 'object') {
+    opts = dft
+    dft = ''
+  }
+
   dft = dft || ''
+  opts = opts || {}
 
   assert.equal(typeof dft, 'string', 'dft should be a string')
+  assert.equal(typeof opts, 'object', 'opts should be an object')
 
   const router = wayfarer(dft + '/GET')
 
@@ -26,12 +33,15 @@ function serverRouter (dft) {
     assert.equal(typeof route, 'string', 'route should be a string')
     route = (route || '').replace(/^\//, '')
 
+    // allow wrapping for custom intrumentation
+    if (opts.wrap) cbs = opts.wrap(cbs)
+
     if (cbs && cbs._router) {
       router.on(route, cbs._router)
     } else if (typeof cbs === 'function') {
       // register a single function as GET
       router.on(route + '/GET', wrap(cbs))
-    } else {
+    } else if (typeof cbs === 'object') {
       // register an object of HTTP methods
       Object.keys(cbs).forEach(function (method) {
         const ok = methods.indexOf(method.toUpperCase)

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ const serverRouter = require('./')
 
 test('should assert input types', function (t) {
   t.plan(2)
-  t.throws(serverRouter.bind(null, {}))
+  t.throws(serverRouter.bind(null, 1235))
   t.doesNotThrow(serverRouter.bind(null))
 })
 
@@ -163,4 +163,28 @@ test('nest routers with partials', function (t) {
       server.close()
     })
   })
+})
+
+test('wrap paths', function (t) {
+  t.plan(2)
+
+  const r = serverRouter({ wrap: wrapFunction() })
+  r.on('/foo', {
+    handler: function (req, res, params) {
+      t.pass('handler called')
+      res.end()
+    }
+  })
+
+  const server = http.createServer(r).listen()
+  http.get('http://localhost:' + getPort(server) + '/foo', function (res) {
+    server.close()
+  })
+
+  function wrapFunction () {
+    t.pass('wrapper called')
+    return function (data) {
+      return data.handler
+    }
+  }
 })


### PR DESCRIPTION
Adds a `{ wrap: function }` option that allows for custom extension of server routes. Useful to catch routes for things like documentation purposes, wrapping with validation middleware; the possibilities are endless. :sparkles:

cc/ @ahdinosaur I reckon you might find it interesting - thoughts?
