### PR TITLE
Fix default path option

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function ServerRouter (opts) {
 
   opts = opts || {}
   assert.equal(typeof opts, 'object', 'server-router: opts should be type object')
-  this._router = wayfarer()
+  this._router = wayfarer(opts.default)
 }
 
 ServerRouter.prototype.route = function (method, route, handler) {


### PR DESCRIPTION
```
# should register a default path
/home/jamen/new/server-router/node_modules/wayfarer/index.js:63
    throw new Error("route '" + route + "' did not match")
    ^

Error: route 'GET/bar' did not match
```