### PR TITLE
Pass default route to `wayfarer`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function ServerRouter (opts) {
 
   opts = opts || {}
   assert.equal(typeof opts, 'object', 'server-router: opts should be type object')
-  this._router = wayfarer()
+  this._router = wayfarer(opts.default)
 }
 
 ServerRouter.prototype.route = function (method, route, handler) {


### PR DESCRIPTION
Naming from https://github.com/choojs/wayfarer/blob/master/index.js#L11

Or else `server-router` breaks on unknown routes:
```
/home/something/node_modules/wayfarer/index.js:69
    throw new Error("route '" + route + "' did not match")
    ^

Error: route 'GET/yo/how/are/u' did not match
    at match (/home/something/node_modules/wayfarer/index.js:69:11)
    at ServerRouter.emit [as _router] (/home/something/node_modules/wayfarer/index.js:49:19)
    at ServerRouter.match (/home/something/node_modules/server-router/index.js:40:15)
    at Server.<anonymous> (/home/something/node_modules/server-router/index.js:46:10)
    at Server.emit (events.js:198:13)
    at parserOnIncoming (_http_server.js:677:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:109:17)
```